### PR TITLE
feat:ホームで表示するカードを作成

### DIFF
--- a/src/components/common/MainCard.tsx
+++ b/src/components/common/MainCard.tsx
@@ -1,0 +1,43 @@
+import { Card, CardMedia, Box, CardContent, Typography } from '@mui/material';
+
+type propsType = {
+  image: string;
+  title: string;
+  detail: string;
+};
+
+export const MainCard = (props: propsType) => {
+  return (
+    <Card sx={{ display: 'flex', width: '100vw' }}>
+      <CardMedia
+        image={props.image}
+        title="画像"
+        sx={{
+          height: 75,
+          width: '20vw',
+          objectFit: 'cover',
+          padding: 2,
+        }}
+      />
+      <Box sx={{ display: 'flex', flexDirection: 'column', width: '80vw' }}>
+        <CardContent sx={{ flex: '1 0 auto' }}>
+          <Typography component="div" variant="h6">
+            {props.title}
+          </Typography>
+          <Typography
+            variant="subtitle2"
+            color="text.secondary"
+            component="div"
+            sx={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {props.detail}
+          </Typography>
+        </CardContent>
+      </Box>
+    </Card>
+  );
+};


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: `Main`コンポーネントに新しい`Router`コンポーネントを追加しました。`Router`コンポーネントは`react-router-dom`を使用してReactアプリケーションのルーティングを設定します。
- 新機能: `MainCard`コンポーネントが追加されました。このコンポーネントは画像、タイトル、詳細を表示するカードをレンダリングします。スタイリングにはMaterial-UIコンポーネントが使用されています。
- 新機能: `Error`コンポーネントが追加されました。このコンポーネントは、ページが見つからなかった場合に表示されるエラーメッセージを提供します。
- 新機能: `Top`コンポーネントが追加され、Reactの状態フックである`useState`が使用されています。

> "新しい機能が輝く！エラーもなく、ルーティングもスムーズ。開発者の手腕に拍手喝采！🎉"
<!-- end of auto-generated comment: release notes by openai -->