### PR TITLE
feat: ホームタブを作成/カードバグ修正

### DIFF
--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -1,0 +1,74 @@
+import { Box, Tab, Tabs, Typography } from '@mui/material';
+import React from 'react';
+import { Latest } from './Latest';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ p: 3 }}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+export const Header = () => {
+  const [value, setValue] = React.useState(0);
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+  return (
+    <header>
+      <Typography
+        variant="h5"
+        sx={{
+          textAlign: 'center',
+          fontWeight: 'bold',
+          padding: '10px 0',
+        }}
+      >
+        じもとコイン
+      </Typography>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          aria-label="basic tabs example"
+          centered
+        >
+          <Tab label="最近の投稿" {...a11yProps(0)} />
+          <Tab label="新着質問" {...a11yProps(1)} />
+        </Tabs>
+      </Box>
+      <CustomTabPanel value={value} index={0}>
+        <Latest />
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={1}>
+        新着質問画面
+      </CustomTabPanel>
+    </header>
+  );
+};

--- a/src/components/Home/Latest.tsx
+++ b/src/components/Home/Latest.tsx
@@ -1,0 +1,19 @@
+import { Container } from '@mui/material';
+import { MainCard } from '../common/MainCard';
+
+export const Latest = () => {
+  return (
+    <Container maxWidth="sm">
+      <MainCard
+        image="https://source.unsplash.com/random"
+        title="Test"
+        detail="testtesttesttesttesttesttesttesttesttesttesttesttest"
+      />
+      <MainCard
+        image="https://source.unsplash.com/random"
+        title="Test"
+        detail="testtesttesttesttesttesttesttesttesttesttesttesttest"
+      />
+    </Container>
+  );
+};

--- a/src/components/common/MainCard.tsx
+++ b/src/components/common/MainCard.tsx
@@ -8,36 +8,47 @@ type propsType = {
 
 export const MainCard = (props: propsType) => {
   return (
-    <Card sx={{ display: 'flex', width: '100vw' }}>
-      <CardMedia
-        image={props.image}
-        title="画像"
-        sx={{
-          height: 75,
-          width: '20vw',
-          objectFit: 'cover',
-          padding: 2,
-        }}
-      />
-      <Box sx={{ display: 'flex', flexDirection: 'column', width: '80vw' }}>
-        <CardContent sx={{ flex: '1 0 auto' }}>
-          <Typography component="div" variant="h6">
-            {props.title}
-          </Typography>
-          <Typography
-            variant="subtitle2"
-            color="text.secondary"
-            component="div"
-            sx={{
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {props.detail}
-          </Typography>
-        </CardContent>
-      </Box>
-    </Card>
+    <Box marginBottom={1}>
+      <Card sx={{ display: 'flex' }}>
+        <CardMedia
+          image={props.image}
+          title="画像"
+          sx={{
+            height: 75,
+            width: 75,
+            minWidth: 75,
+            objectFit: 'cover',
+            padding: 2,
+          }}
+        />
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+          <CardContent sx={{ flex: '1 0 auto' }}>
+            <Typography
+              component="div"
+              variant="h6"
+              sx={{
+                width: '164px',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+              }}
+            >
+              {props.title}
+            </Typography>
+            <Typography
+              variant="subtitle2"
+              color="text.secondary"
+              component="div"
+              sx={{
+                width: '164px',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+              }}
+            >
+              {props.detail}
+            </Typography>
+          </CardContent>
+        </Box>
+      </Card>
+    </Box>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,9 @@
-import { useContext } from 'react';
-import { AuthContext } from '../contexts/AuthContexts';
+import { Header } from '../components/Home/Header';
 
 const AppHome = () => {
-  const { profile, isLogIn } = useContext(AuthContext);
-
   return (
     <div className="App">
-      <header className="App-header">
-        アプリ画面{isLogIn ? 'ログイン中' : 'ログインしていません'}
-        {profile ? profile.displayName : 'no profile'}
-      </header>
+      <Header />
     </div>
   );
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -14,24 +14,23 @@ export const Router = () => {
     <BrowserRouter>
       <Suspense fallback={<Loading />}>
         <AuthProvider>
-        <Routes>
-          <Route
-            path="/app"
-            element={
-              <>
-                <Outlet />
-                <Navber />
-              </>
-            }
-          >
-            <Route element={<Top />} />
-             <Route path="/home" element={<Home />} />
-            <Route path="*" element={<Error />} />
-          </Route>
-        </Routes>
-          </AuthProvider>
+          <Routes>
+            <Route
+              path="/app"
+              element={
+                <>
+                  <Outlet />
+                  <Navber />
+                </>
+              }
+            >
+              <Route element={<Top />} />
+              <Route path="/app/home" element={<Home />} />
+              <Route path="*" element={<Error />} />
+            </Route>
+          </Routes>
+        </AuthProvider>
       </Suspense>
-        
     </BrowserRouter>
   );
 };


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: ホームタブが追加され、カードバグが修正されました。
- 新機能: ホームタブに2つのメインカードが追加されました。
- リファクタリング: `MainCard`コンポーネントのレンダリングが変更され、カードのレイアウトとスタイリングが調整されました。
- ルーティングの変更: `/app/home`パスに対して`<Home />`コンポーネントが表示されるように修正されました。

> "新しいホームタブが輝く 🌟
> カードバグも修正済み ✨
> メインカードが2つ増えて
> さらなる魅力を放つ 🌈"
<!-- end of auto-generated comment: release notes by openai -->