### PR TITLE
feat: プロフィール画面を作成

### DIFF
--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -1,6 +1,6 @@
 import { Box, Tab, Tabs, Typography } from '@mui/material';
 import React from 'react';
-import { Latest } from './Latest';
+import { TestCard } from '../common/TestCard';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -20,7 +20,7 @@ function CustomTabPanel(props: TabPanelProps) {
       {...other}
     >
       {value === index && (
-        <Box sx={{ p: 3 }}>
+        <Box sx={{ p: 1, pt: 2 }}>
           <Box>{children}</Box>
         </Box>
       )}
@@ -68,7 +68,7 @@ export const Header = () => {
         </Box>
       </header>
       <CustomTabPanel value={value} index={0}>
-        <Latest />
+        <TestCard />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
         新着質問画面

--- a/src/components/common/TestCard.tsx
+++ b/src/components/common/TestCard.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@mui/material';
-import { MainCard } from '../common/MainCard';
+import { MainCard } from './MainCard';
 
-export const Latest = () => {
+export const TestCard = () => {
   return (
     <Container maxWidth="sm" sx={{ paddingBottom: '35px' }}>
       <MainCard

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -1,0 +1,108 @@
+import { Avatar, Box, IconButton, Tab, Tabs, Typography } from '@mui/material';
+import React, { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContexts';
+import { TestCard } from '../components/common/TestCard';
+import { Settings } from '@mui/icons-material';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ p: 1, pt: 2 }}>
+          <Box>{children}</Box>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+const Profile = () => {
+  const [value, setValue] = React.useState(0);
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+  const { profile } = useContext(AuthContext);
+  return (
+    <>
+      <header>
+        <Box top={0} bgcolor={'white'}>
+          <Box margin={3}>
+            <Box display={'flex'} justifyContent={'center'} mb={2}>
+              <Avatar
+                alt={profile ? profile.displayName : 'no profile'}
+                src={profile && profile.pictureUrl ? profile.pictureUrl : ''}
+                sx={{ width: 56, height: 56, marginRight: 2 }}
+              />
+              <Typography
+                variant="h5"
+                component="div"
+                display={'flex'}
+                alignItems={'center'}
+              >
+                {profile ? profile.displayName : 'no profile'}
+              </Typography>
+              <IconButton>
+                <Settings />
+              </IconButton>
+            </Box>
+            <Box
+              display={'flex'}
+              alignItems={'flex-end'}
+              justifyContent={'center'}
+            >
+              <Typography variant="body2" component="div" marginRight={2}>
+                残高
+              </Typography>
+              <Typography variant="h2" component="div" fontWeight={'bold'}>
+                {/* TODO: コイン数表示 */}0
+              </Typography>
+              <Typography variant="body2" component="div" marginLeft={2}>
+                コイン
+              </Typography>
+            </Box>
+          </Box>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tabs
+              value={value}
+              onChange={handleChange}
+              aria-label="basic tabs example"
+              centered
+            >
+              <Tab label="投稿" {...a11yProps(0)} />
+              <Tab label="お気に入り" {...a11yProps(1)} />
+            </Tabs>
+          </Box>
+        </Box>
+      </header>
+      <CustomTabPanel value={value} index={0}>
+        <TestCard />
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={1}>
+        <TestCard />
+      </CustomTabPanel>
+    </>
+  );
+};
+
+export default Profile;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -8,6 +8,7 @@ import { Navber } from '../components/Navber';
 const Error = lazy(() => import('../pages/Error'));
 const Home = lazy(() => import('../pages/Home'));
 const Map = lazy(() => import('../pages/Map'));
+const User = lazy(() => import('../pages/User'));
 
 export const Router = () => {
   return (
@@ -26,6 +27,7 @@ export const Router = () => {
             >
               <Route path="/app/map" element={<Map />} />
               <Route path="/app/home" element={<Home />} />
+              <Route path="/app/user" element={<User />} />
               <Route path="*" element={<Error />} />
             </Route>
           </Routes>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: ユーザープロフィールページを表示するための`Profile`コンポーネントが追加されました。アバター、表示名、設定ボタン、残高情報、および投稿とお気に入りを表示するためのタブなど、さまざまなUI要素が含まれています。
- リファクタ: `Header.tsx`と`TestCard.tsx`のインポート文が`Latest`ではなく`TestCard`を使用するように変更されました。また、ボックス要素のパディングも調整されました。
- リファクタ: `/app/user`パスに対して新しいルートが追加され、`User`コンポーネントがレンダリングされるようになりました。

> 🎉 変更の詩:
>
> このPRには
> 新機能とリファクタがあります
> ユーザープロフィールのページが追加され
> インポート文も修正されました
> 変更を祝福しましょう！ 🎉
<!-- end of auto-generated comment: release notes by openai -->