### PR TITLE
style: ホームのタイトルにて上のみpaddingが効くよう設定

### DIFF
--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -49,7 +49,7 @@ export const Header = () => {
             sx={{
               textAlign: 'center',
               fontWeight: 'bold',
-              padding: '10px 0',
+              paddingTop: 2,
             }}
           >
             じもとコイン


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- スタイル: ホームのタイトルの上部にパディングが適用されるように変更されました。

> "小さな調整、見た目も良くなり、ユーザーに喜びをもたらす。🎉"
<!-- end of auto-generated comment: release notes by openai -->