### PR TITLE
feat: 投稿詳細画面を作成

### DIFF
--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,0 +1,109 @@
+import { Close, Delete, LocationOn } from '@mui/icons-material';
+import { Avatar, Box, IconButton, Paper, Typography } from '@mui/material';
+import { AuthContext } from '../contexts/AuthContexts';
+import { useContext } from 'react';
+
+const Detail = () => {
+  const { profile } = useContext(AuthContext);
+  return (
+    <>
+      <Box padding={2} display={'flex'}>
+        <IconButton
+          sx={{ marginRight: 1 }}
+          onClick={() => window.history.back()}
+        >
+          <Close />
+        </IconButton>
+        <Typography
+          variant="h6"
+          fontWeight={'bold'}
+          display={'flex'}
+          alignItems={'center'}
+          justifyContent={'center'}
+        >
+          詳細
+        </Typography>
+        <IconButton sx={{ marginLeft: 'auto' }}>
+          <Delete />
+        </IconButton>
+      </Box>
+      <Box paddingLeft={5} paddingBottom={1} display={'flex'}>
+        <Avatar
+          alt={profile ? profile.displayName : 'no profile'}
+          src={profile && profile.pictureUrl ? profile.pictureUrl : ''}
+          sx={{ width: 28, height: 28, marginRight: 1 }}
+        />
+        <Typography
+          variant="subtitle1"
+          component="div"
+          display={'flex'}
+          alignItems={'center'}
+        >
+          {profile ? profile.displayName : 'no profile'}
+        </Typography>
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="center"
+        flexDirection="column"
+        alignItems="center"
+        paddingBottom={1}
+      >
+        <Box>
+          <Typography
+            variant="h6"
+            fontWeight="bold"
+            mt={1}
+            textAlign={'center'}
+          >
+            {/* TODO: タイトル */}
+            琵琶湖の眺め
+          </Typography>
+        </Box>
+      </Box>
+      <Box display="flex" justifyContent="center">
+        <Paper elevation={3} style={{ width: '80%', overflow: 'hidden' }}>
+          {/* TODO: 画像を表示する */}
+          <img
+            src="https://source.unsplash.com/random"
+            style={{ width: '100%', display: 'block' }}
+          />
+        </Paper>
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="center"
+        flexDirection="column"
+        alignItems="center"
+        paddingTop={0.2}
+      >
+        <Box>
+          <Typography
+            variant="subtitle1"
+            fontWeight="bold"
+            textAlign={'center'}
+          >
+            {/* TODO: サブタイトル */}
+            ここから見える景色は地元民のみぞ知る
+          </Typography>
+        </Box>
+      </Box>
+      <Box paddingTop={2} paddingLeft={5} display={'flex'}>
+        <LocationOn sx={{ marginRight: 1 }} />
+        <Typography variant="body2" display={'flex'} alignItems={'center'}>
+          滋賀県大津市
+        </Typography>
+      </Box>
+      <Box
+        paddingTop={1}
+        paddingRight={5}
+        display={'flex-end'}
+        textAlign={'right'}
+      >
+        <Typography variant="body2">2023年8月24日</Typography>
+      </Box>
+    </>
+  );
+};
+
+export default Detail;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -7,6 +7,7 @@ import { Navber } from '../components/Navber';
 
 const Error = lazy(() => import('../pages/Error'));
 const Home = lazy(() => import('../pages/Home'));
+const Detail = lazy(() => import('../pages/Detail'));
 const Map = lazy(() => import('../pages/Map'));
 const Search = lazy(() => import('../pages/Search'));
 const User = lazy(() => import('../pages/User'));
@@ -28,6 +29,7 @@ export const Router = () => {
             >
               <Route path="/app/map" element={<Map />} />
               <Route path="/app/home" element={<Home />} />
+              <Route path="/app/home/detail/:id" element={<Detail />} />
               <Route path="/app/search" element={<Search />} />
               <Route path="/app/user" element={<User />} />
               <Route path="*" element={<Error />} />


### PR DESCRIPTION
- close #29 
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: `Detail` コンポーネントが追加されました。このコンポーネントは投稿の詳細を表示し、ユーザーのプロフィール情報、投稿タイトル、画像、サブタイトル、場所、日付を含みます。
- ルーター設定に詳細ページ用の新しいルートが追加されました。

> "新たな詳細が輝く、投稿の世界。
> ユーザーの情報、タイトル、画像も備えて。
> サブタイトル、場所、そして日付も。
> 進化するアプリ、喜び溢れる。"
<!-- end of auto-generated comment: release notes by openai -->