### PR TITLE
登録画面に遷移させるようにする

### DIFF
--- a/src/contexts/AuthContexts.tsx
+++ b/src/contexts/AuthContexts.tsx
@@ -2,10 +2,11 @@ import type { Profile } from '@liff/get-profile';
 import liff from '@line/liff';
 import { LiffMockPlugin } from '@line/liff-mock';
 import { createContext, ReactNode, useEffect, useState } from 'react';
-import { Question } from '../types/questions';
+import { useNavigate } from 'react-router-dom';
 
 import { CoinLog } from '../types/coinLog';
 import { Favorite } from '../types/favorite';
+import { Question } from '../types/questions';
 import { Report } from '../types/report';
 import { User } from '../types/user';
 
@@ -40,6 +41,7 @@ export const AuthProvider = ({ children }: Props) => {
   const [questions, setQuestions] = useState<Question[]>(() => []);
   const [favorites, setFavorites] = useState<Favorite[]>(() => []);
   const [coinLogs, setCoinLogs] = useState<CoinLog[]>(() => []);
+  const navigate = useNavigate();
 
   const isError = profile === null;
 
@@ -122,7 +124,8 @@ export const AuthProvider = ({ children }: Props) => {
       if (userData.prefecture == null || userData.city == null) {
         setHasHomeTown(false);
         console.log('地元が登録されていません');
-        // todo - Register画面に遷移させたい
+        // register画面に遷移する
+        navigate('/register');
         return;
       }
 

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -10,6 +10,7 @@ const Home = lazy(() => import('../pages/Home'));
 const Map = lazy(() => import('../pages/Map'));
 const Search = lazy(() => import('../pages/Search'));
 const User = lazy(() => import('../pages/User'));
+const Register = lazy(() => import('../pages/Register'));
 
 export const Router = () => {
   return (
@@ -30,8 +31,9 @@ export const Router = () => {
               <Route path="/app/home" element={<Home />} />
               <Route path="/app/search" element={<Search />} />
               <Route path="/app/user" element={<User />} />
-              <Route path="*" element={<Error />} />
             </Route>
+            <Route path="/register" element={<Register />} />
+            <Route path="*" element={<Error />} />
           </Routes>
         </AuthProvider>
       </Suspense>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: "Register"ページのための新しいルートが追加されました。
- バグ修正: `react-router-dom`ライブラリから`useNavigate`フックのインポートステートメントが追加されました。
- バグ修正: 特定の条件が満たされた場合に、'/register'ルートに移動するようにコードが変更されました。

> 新しいルートが追加され、'/register'へのナビゲーションが改善されました。🚀


<!-- end of auto-generated comment: release notes by openai -->