### PR TITLE
feat: 追加モーダルを作成

### DIFF
--- a/src/components/AddModal/Place.tsx
+++ b/src/components/AddModal/Place.tsx
@@ -1,0 +1,86 @@
+import { Button, Stack, TextField } from '@mui/material';
+import { useCallback, useState } from 'react';
+import SendIcon from '@mui/icons-material/Send';
+
+export const Place = () => {
+  const [title, setTitle] = useState('');
+  const [subTitle, setSubTitle] = useState('');
+  const [hasTitleError, setHasTitleError] = useState(false);
+  const [hasSubTitleError, setHasSubTitleError] = useState(false);
+
+  const inputTitle = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const inputValue = event.target.value;
+      const isEmpty = inputValue === '';
+      setTitle(inputValue);
+      setHasTitleError(isEmpty);
+    },
+    [setTitle, setHasTitleError]
+  );
+
+  const inputSubTitle = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const inputValue = event.target.value;
+
+      const isEmpty = inputValue === '';
+      setSubTitle(inputValue);
+      setHasSubTitleError(isEmpty);
+    },
+    [setSubTitle, setHasSubTitleError]
+  );
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    console.log(`Sybmit Title: ${title}`);
+    console.log(`Sybmit SubTitle: ${subTitle}`);
+  };
+
+  return (
+    <Stack
+      component="form"
+      noValidate
+      onSubmit={handleSubmit}
+      spacing={2}
+      sx={{
+        m: 2,
+        width: '25ch',
+        display: 'flex',
+        alignContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <TextField
+        sx={{ width: '100%' }}
+        type="text"
+        label="タイトル"
+        required
+        value={title}
+        error={hasTitleError}
+        onChange={inputTitle}
+        helperText={hasTitleError ? 'タイトルを入力してください。' : ''}
+      />
+      <TextField
+        sx={{ width: '100%' }}
+        type="text"
+        label="サブタイトル"
+        required
+        value={subTitle}
+        error={hasSubTitleError}
+        onChange={inputSubTitle}
+        helperText={hasSubTitleError ? 'サブタイトルを入力してください。' : ''}
+      />
+      <Button
+        variant="outlined"
+        endIcon={<SendIcon />}
+        type="submit"
+        sx={{
+          borderRadius: 2,
+          width: '75%',
+        }}
+      >
+        投稿
+      </Button>
+    </Stack>
+  );
+};

--- a/src/components/AddModal/Question.tsx
+++ b/src/components/AddModal/Question.tsx
@@ -1,0 +1,5 @@
+import { Typography } from '@mui/material';
+
+export const Question = () => {
+  return <Typography>Question</Typography>;
+};

--- a/src/components/common/AddFab.tsx
+++ b/src/components/common/AddFab.tsx
@@ -1,12 +1,23 @@
 import { Box, Fab } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import { AddModal } from './AddModal';
+import { useState } from 'react';
 
 export const AddFab = () => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
   return (
-    <Box role="presentation" sx={{ position: 'fixed', bottom: 80, right: 16 }}>
-      <Fab color="info">
-        <AddIcon />
-      </Fab>
-    </Box>
+    <>
+      <Box
+        role="presentation"
+        sx={{ position: 'fixed', bottom: 80, right: 16 }}
+      >
+        <Fab color="info" onClick={handleOpen}>
+          <AddIcon />
+        </Fab>
+      </Box>
+      <AddModal open={open} handleClose={handleClose} />
+    </>
   );
 };

--- a/src/components/common/AddModal.tsx
+++ b/src/components/common/AddModal.tsx
@@ -1,0 +1,88 @@
+import {
+  Avatar,
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Modal,
+  Select,
+  SelectChangeEvent,
+  Typography,
+} from '@mui/material';
+import { useContext, useState } from 'react';
+import { AuthContext } from '../../contexts/AuthContexts';
+import { Place } from '../AddModal/Place';
+import { Question } from '../AddModal/Question';
+
+interface Props {
+  open: boolean;
+  handleClose: () => void;
+}
+
+const style = {
+  position: 'absolute' as const,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '75vw',
+  bgcolor: 'background.paper',
+  borderRadius: '0.5rem',
+  boxShadow: 24,
+  p: 4,
+};
+
+export const AddModal = (prop: Props) => {
+  const [age, setAge] = useState('place');
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setAge(event.target.value);
+  };
+  const { profile } = useContext(AuthContext);
+  return (
+    <Modal open={prop.open} onClose={prop.handleClose}>
+      <Box sx={style} display={'block'}>
+        <Box alignItems={'center'} display={'flex'}>
+          <Avatar
+            alt={profile ? profile.displayName : 'no profile'}
+            src={profile && profile.pictureUrl ? profile.pictureUrl : ''}
+            sx={{
+              width: 28,
+              height: 28,
+              marginRight: 1,
+            }}
+          />
+          <FormControl
+            sx={{
+              m: 1,
+              minWidth: 120,
+              marginLeft: 'auto',
+              alignItems: 'center',
+            }}
+            size="small"
+          >
+            <InputLabel id="small-label"></InputLabel>
+            <Select
+              labelId="small-label"
+              id="small"
+              value={age}
+              label="Age"
+              onChange={handleChange}
+            >
+              <MenuItem value="place">場所</MenuItem>
+              <MenuItem value="question">質問</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+        <Box display={'flex'}>
+          {age === 'place' ? (
+            <Place />
+          ) : age === 'question' ? (
+            <Question />
+          ) : (
+            <Typography>投稿方法を選択してください</Typography>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+};


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: 追加モーダルが追加されました。ユーザーはタイトルとサブタイトルの入力フィールドを持つモーダルを表示し、バリデーションと送信ボタンを使用して場所や質問の投稿方法を選択できます。
- バグ修正: なし
- ドキュメント: なし
- リファクタリング: なし
- スタイル: なし
- テスト: なし
- 雑務: なし
- リバート: なし

> "新しい機能が輝く！ユーザーは場所や質問を追加するためのモーダルを楽しむ♪"
<!-- end of auto-generated comment: release notes by openai -->