### PR TITLE
feat: update filter compo

### DIFF
--- a/src/components/Home/Content.tsx
+++ b/src/components/Home/Content.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react';
 import { Box, Container } from '@mui/material';
 
 import { MainCard } from '../common/MainCard';
+import { Filter } from '../common/Filter';
 
-import { useContext } from 'react';
 import { AuthContext } from '../../contexts/AuthContexts';
 
 interface TabPanelProps {
@@ -36,12 +37,20 @@ type ContentProps = {
 };
 
 export const Content = ({ value }: ContentProps) => {
-  const { reports, questions } = useContext(AuthContext);
+  const [address, setAddress] = React.useState('');
+  console.log(address);
+
+  React.useEffect(() => {}, [address]);
+
+  const { reports, questions } = React.useContext(AuthContext);
   return (
     <>
       <CustomTabPanel value={value} index={0}>
+        <Box display="flex" justifyContent="flex-end">
+          <Filter filterKey="home" setAddress={setAddress} />
+        </Box>
         {/* reportsを.mapして、MainCardに入れる*/}
-        <Container maxWidth="sm" sx={{ paddingBottom: '35px' }}>
+        <Container maxWidth="sm" sx={{ mt: 1, paddingBottom: '35px' }}>
           {reports.map((report) => (
             <MainCard
               key={report.id}

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -1,6 +1,7 @@
-import { Box, Tab, Tabs, Typography } from '@mui/material';
-import React from 'react';
+import * as React from 'react';
+
 import { Content } from './Content';
+import { Box, Tab, Tabs, Typography } from '@mui/material';
 
 function a11yProps(index: number) {
   return {

--- a/src/components/Register/Confilm.tsx
+++ b/src/components/Register/Confilm.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-
 import { Box, Button, Card, Typography } from '@mui/material';
 
 import { japan } from '../../lib/japan';

--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -1,66 +1,129 @@
+import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { FormControl, Select, MenuItem, Grid } from '@mui/material';
+import { AuthContext } from '../../contexts/AuthContexts';
+
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Container,
+  Typography,
+} from '@mui/material';
 
 import { japan } from '../../lib/japan';
 import { getCity } from '../../lib/getAddress';
-import { Dispatch, SetStateAction } from 'react';
+import { User } from '../../types/user';
 
 interface propsType {
-  prefecture: string;
-  setPrefecture: Dispatch<SetStateAction<string>>;
-  city: string;
-  setCity: Dispatch<SetStateAction<string>>;
+  filterKey: string;
+  setAddress: React.Dispatch<React.SetStateAction<string>>;
 }
 
+const getStringPrefecture = (prefId: string) => {
+  const result = japan.filter((value) => value.id === prefId);
+
+  if (result.length > 0) {
+    return result[0].name;
+  }
+
+  return '';
+};
+
 export const Filter = (prop: propsType) => {
+  const { user } = React.useContext(AuthContext);
+  if (user === null) return null;
+
+  return <Inner {...prop} user={user} />;
+};
+
+const Inner = (prop: propsType & { user: User }) => {
+  const { user } = prop;
+
+  const [prefecture, setPrefecture] = React.useState(user.prefecture);
+  const [city, setCity] = React.useState(user.city);
+
   const prefectureLs = japan.map((value) => {
     return (
-      <MenuItem key={value.id} value={value.id}>
+      <MenuItem key={prop.filterKey + value.id} value={value.id}>
         {value.name}
       </MenuItem>
     );
   });
 
-  const citiesArr = useQuery(['cities', prop.prefecture], () =>
-    getCity(prop.prefecture)
-  );
+  const citiesArr = useQuery(['cities', prefecture], () => getCity(prefecture));
 
-  let cityLs;
+  let cityLs, stringCity: { name: string };
   if (citiesArr && citiesArr.data && citiesArr.data.data) {
+    stringCity = citiesArr.data.data.find(
+      (obj: { id: string }) => obj.id === city
+    );
+
     cityLs = citiesArr.data.data.map((value: { id: string; name: string }) => {
       return (
-        <MenuItem key={value.id} value={value.id}>
+        <MenuItem key={prop.filterKey + value.id} value={value.id}>
           {value.name}
         </MenuItem>
       );
     });
   }
 
+  React.useEffect(() => {
+    if (!city) {
+      return;
+    }
+
+    prop.setAddress(getStringPrefecture(prefecture) + stringCity?.name);
+  }, [city, citiesArr]);
+
   return (
-    <Grid>
-      <FormControl>
-        <Select
-          value={prop.prefecture}
-          label="都道府県"
-          onChange={({ target }) => {
-            prop.setPrefecture(target.value);
-          }}
-        >
-          {prefectureLs}
-        </Select>
-      </FormControl>
-      <FormControl>
-        <Select
-          value={prop.city}
-          label="市区町村"
-          onChange={({ target }) => {
-            prop.setCity(target.value);
-          }}
-        >
-          {cityLs}
-        </Select>
-      </FormControl>
-    </Grid>
+    <Container
+      maxWidth="sm"
+      sx={{ display: 'flex', justifyContent: 'flex-end' }}
+    >
+      <Box sx={{ mr: 1, minWidth: '20%' }}>
+        <FormControl fullWidth size="small">
+          <InputLabel id="prefecture-label">都道府県</InputLabel>
+          <Select
+            labelId="prefecture-label"
+            id={prop.filterKey + '-prefecture'}
+            value={prefecture}
+            label="都道府県"
+            onChange={({ target }) => {
+              setPrefecture(target.value);
+              setCity('');
+            }}
+          >
+            {prefectureLs}
+          </Select>
+        </FormControl>
+      </Box>
+      <Box
+        sx={{ mr: 1, minWidth: '5%' }}
+        display="flex"
+        alignItems="center"
+        justifyContent={'center'}
+      >
+        <Typography variant="body1">の</Typography>
+      </Box>
+      <Box sx={{ mr: 1, minWidth: '20%' }}>
+        <FormControl fullWidth size="small">
+          <InputLabel id="city-label">市区町村</InputLabel>
+          <Select
+            labelId="city-label"
+            id={prop.filterKey + '-city'}
+            value={city}
+            label="市区町村"
+            onChange={({ target }) => {
+              setCity(target.value);
+            }}
+          >
+            {cityLs}
+          </Select>
+        </FormControl>
+      </Box>
+    </Container>
   );
 };

--- a/src/contexts/AuthContexts.tsx
+++ b/src/contexts/AuthContexts.tsx
@@ -118,13 +118,14 @@ export const AuthProvider = ({ children }: Props) => {
       const resData = await res.json();
 
       const userData = resData['User'] as User;
-      setUser(userData);
+      setUser({ ...userData, prefecture: '22', city: '22210' });
 
       // 地元が登録されているかどうかを確認
       if (userData.prefecture == null || userData.city == null) {
         setHasHomeTown(false);
         console.log('地元が登録されていません');
         // register画面に遷移する
+
         navigate('/register');
         return;
       }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,22 +1,10 @@
-import * as React from 'react';
 import { Header } from '../components/Home/Header';
 import { AddFab } from '../components/common/AddFab';
-import { Filter } from '../components/common/Filter';
 
 const AppHome = () => {
-  const [prefecture, setPrefecture] = React.useState('');
-  const [city, setCity] = React.useState('');
-
   return (
     <div className="App">
       <Header />
-      <Filter
-        prefecture={prefecture}
-        setPrefecture={setPrefecture}
-        city={city}
-        setCity={setCity}
-      />
-
       <AddFab />
     </div>
   );


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: `Content.tsx` に新しい状態変数 `address` と、その値をログ出力するエフェクトフックが追加されました。
- 機能改善: `Content.tsx` の `Container` コンポーネントの `sx` プロップに追加のスタイルが適用されるように更新されました。
- 新機能: `Content.tsx` に `Filter` コンポーネントのインポートステートメントが追加されました。
- 新機能: `Filter.tsx` に `Filter` コンポーネントが追加されました。このコンポーネントは都道府県と市を選択するためのドロップダウンメニューを含むフォームをレンダリングします。選択された値は状態変数に保存され、データの取得に使用されます。また、いくつかのUIの改善も含まれています。
- リファクタリング: `Header.tsx` のインポートステートメントが更新され、`React` ライブラリの個別のインポートからワイルドカードインポートに変更されました。
- リファクタリング: `Confilm.tsx` の `useQuery` のインポートステートメントが削除されました。
- 機能改善: `AuthContexts.tsx` の `setUser` 関数呼び出しが更新され、`userData` オブジェクトを展開し、`prefecture` と `city` の追加プロパティが追加されました。また、ユーザーの出身地が登録されていない場合に `/register` ページへのナビゲーションが追加されました。
- リファクタリング: `Home.tsx` の `Filter` コンポーネントのインポートステートメントとそれに対応する `AppHome` コンポーネントでの使用が削除されました。

> 新機能が輝く
> バグ修正もある
> 祝福の詩

(> symbol)
<!-- end of auto-generated comment: release notes by openai -->