### PR TITLE
投稿をAPIを叩いて可能にする

### DIFF
--- a/src/components/AddModal/Place.tsx
+++ b/src/components/AddModal/Place.tsx
@@ -1,3 +1,4 @@
+import liff from '@line/liff';
 import SendIcon from '@mui/icons-material/Send';
 import { Box, Button, Container, Stack, TextField } from '@mui/material';
 import { useCallback, useState } from 'react';
@@ -48,11 +49,38 @@ export const Place = () => {
     console.log(`Sybmit Title: ${title}`);
     console.log(`Sybmit SubTitle: ${subTitle}`);
 
+    let uploadImageUrl = '';
     if (imageData) {
       // 画像データをアップロードしてURLに変更する
       const url = await uploadImage(imageData, 'test');
-      console.log(url);
+      uploadImageUrl = url;
     }
+
+    const baseUrl = process.env.REACT_APP_API_BASE_URL;
+    if (!baseUrl) {
+      console.log('baseUrl is undefined');
+      return;
+    }
+
+    // APIにリクエスト
+    const options = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        idToken: liff.getIDToken() ?? 'id_token',
+        title,
+        content: subTitle,
+        // todo - Registerが実装後、ユーザーの地元情報を取得する
+        address: '静岡県静岡市',
+        lat: 34.976944,
+        lng: 38.383056,
+        urls: [uploadImageUrl ?? null],
+      }),
+    };
+
+    const res = await fetch(baseUrl + '/report', options);
+    const resData = await res.json();
+    console.log(resData);
   };
 
   return (


### PR DESCRIPTION
![image](https://github.com/prtimes-team2/app-front/assets/54356188/a2aba521-069b-486b-b0f7-ee61acac3fc5)

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: `src/components/AddModal/Place.tsx` において、`liff` モジュールのインポート文が追加され、インポートしたモジュールを使用して API リクエストが行われるようにコードが変更されました。また、画像のアップロードと API へのデータ送信に関する追加のロジックも含まれています。

> "新機能: `liff` モジュールを使って、API リクエストを送信する。
> 画像をアップロードし、データを送信する。
> 開発者の努力が実り、新たな機能が生まれた！"
<!-- end of auto-generated comment: release notes by openai -->