### PR TITLE
feat: get self question

### DIFF
--- a/src/contexts/AuthContexts.tsx
+++ b/src/contexts/AuthContexts.tsx
@@ -5,7 +5,7 @@ import { createContext, ReactNode, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { CoinLog } from '../types/coinLog';
-import { Question } from '../types/questions';
+import { Question, SelfQuestion } from '../types/questions';
 import { Report } from '../types/report';
 import { User } from '../types/user';
 
@@ -17,11 +17,13 @@ class AuthContextProps {
   user: User | null = null;
   reports: Report[] = [];
   questions: Question[] = [];
+  selfQuestions: SelfQuestion[] = [];
   favoriteIds: number[] = [];
   coinLogs: CoinLog[] = [];
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setProfile: (profile: Profile | null) => void = () => {};
   setFavorite: (newValue: boolean, reportId: number) => void = () => {};
+  setSelfQuestions: (newValue: SelfQuestion[]) => void = () => {};
 }
 
 export const AuthContext = createContext<AuthContextProps>(
@@ -38,7 +40,8 @@ export const AuthProvider = ({ children }: Props) => {
   const [hasHomeTown, setHasHomeTown] = useState<boolean>(() => false);
   const [user, setUser] = useState<User | null>(() => null);
   const [reports, setReports] = useState<Report[]>(() => []);
-  const [questions, setQuestions] = useState<Question[]>(() => []);
+  const [questions /* setQuestions*/] = useState<Question[]>(() => []);
+  const [selfQuestions, setSelfQuestions] = useState<SelfQuestion[]>(() => []);
   const [favoriteIds, setFavoriteIds] = useState<number[]>(() => []);
   const [coinLogs, setCoinLogs] = useState<CoinLog[]>(() => []);
   const navigate = useNavigate();
@@ -192,17 +195,6 @@ export const AuthProvider = ({ children }: Props) => {
       }
       setFavoriteIds(favIds);
 
-      const questions = resData['Questions'] as { [key: string]: Question };
-      console.log('---------------- questions ------------');
-      console.log(questions);
-      console.log('---------------- questions ------------');
-
-      if (questions) {
-        setQuestions(transformToArr(questions));
-      } else {
-        setQuestions([]);
-      }
-
       const coinLogs = resData['Coinlogs'] as CoinLog[];
       console.log('---------------- coinLogs ------------');
       console.log(coinLogs);
@@ -213,6 +205,9 @@ export const AuthProvider = ({ children }: Props) => {
       } else {
         setCoinLogs([]);
       }
+
+      // 自分の質問を取得する
+      await getSelfQuestions(idToken);
     } catch (err) {
       // APIのリクエストが失敗した時は、ログイン画面に戻す
       console.log('getUser error');
@@ -240,9 +235,31 @@ export const AuthProvider = ({ children }: Props) => {
     setFavoriteIds(newFavoriteIds);
   };
 
-  function transformToArr<T>(data: { [key: string]: T }): Array<T> {
-    return Object.keys(data).map((key) => data[key]);
-  }
+  const getSelfQuestions = async (idToken: string) => {
+    // 自分の質問を取得する
+    // APIにリクエスト
+    const baseUrl = process.env.REACT_APP_API_BASE_URL;
+    if (!baseUrl) {
+      console.log('baseUrl is undefined');
+      return;
+    }
+
+    // /question/selfにリクエスト
+    const options = {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    const res = await fetch(
+      baseUrl + '/question/self' + `?idToken=${idToken ?? 'id_token'}`,
+      options
+    );
+    const resData = (await res.json()) as SelfQuestion[];
+    console.log(' ---------------- selfQuestion ----------------');
+    console.log(resData);
+    console.log(' ---------------- selfQuestion ----------------');
+    setSelfQuestions(resData);
+  };
 
   useEffect(() => {
     liffInit();
@@ -262,6 +279,8 @@ export const AuthProvider = ({ children }: Props) => {
         favoriteIds,
         coinLogs,
         setFavorite,
+        selfQuestions,
+        setSelfQuestions,
       }}
     >
       {children}

--- a/src/contexts/AuthContexts.tsx
+++ b/src/contexts/AuthContexts.tsx
@@ -130,8 +130,17 @@ export const AuthProvider = ({ children }: Props) => {
       };
 
       const res = await fetch(baseUrl + '/user/login', options);
-      const resData = await res.json();
+      console.log('---------------- res ------------');
+      console.log(res);
+      console.log('---------------- res ------------');
 
+      if (!res.ok) {
+        console.log('res is not ok');
+        const text = await res.text();
+        console.log(text);
+        return;
+      }
+      const resData = await res.json();
       console.log('---------------- resData ------------');
       console.log(resData);
       console.log('---------------- resData ------------');

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -54,7 +54,8 @@ const Profile = () => {
   };
   const [totalCoin, setTotalCoin] = React.useState(0);
 
-  const { profile, coinLogs, reports, favoriteIds } = useContext(AuthContext);
+  const { profile, coinLogs, reports, favoriteIds, selfQuestions } =
+    useContext(AuthContext);
 
   useEffect(() => {
     let total = 0;
@@ -115,7 +116,8 @@ const Profile = () => {
               centered
             >
               <Tab label="投稿" {...a11yProps(0)} />
-              <Tab label="お気に入り" {...a11yProps(1)} />
+              <Tab label="質問" {...a11yProps(1)} />
+              <Tab label="お気に入り" {...a11yProps(2)} />
             </Tabs>
           </Box>
         </Box>
@@ -139,6 +141,14 @@ const Profile = () => {
         </Container>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
+        {/* 自分の投稿した質問を表示したい */}
+        <Container maxWidth="sm" sx={{ paddingBottom: '35px' }}>
+          {selfQuestions.map((selfQuestion) => (
+            <div key={selfQuestion.question_id}>私の質問</div>
+          ))}
+        </Container>
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={2}>
         {/* お気に入りの投稿が表示される reportにあって、favoritesのidのものだけを表示したい */}
         <Container maxWidth="sm" sx={{ paddingBottom: '35px' }}>
           {reports

--- a/src/types/questions.d.ts
+++ b/src/types/questions.d.ts
@@ -6,3 +6,11 @@ export interface Question {
   address: string;
   prefecture: string;
 }
+
+export interface SelfQuestion {
+  question_id: number;
+  displayName: string;
+  profileImageUrl: string;
+  content: string;
+  created_at: string;
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 新機能: `AuthProvider`コンポーネントに新しい状態変数`selfQuestions`とそれに対応するセッター関数`setSelfQuestions`が追加されました。また、`getSelfQuestions`関数が導入され、APIエンドポイントから自己質問を取得し、`selfQuestions`の状態を更新します。
- 変更: `questions`の状態を設定する関連するコードがコメントアウトされました。
- 新機能: プロフィールページに「質問」という新しいタブが追加されました。ユーザーの自己質問を表示するセクションも含まれており、"お気に入り"タブのインデックスが変更されました。

> 「質問」という新たなタブ
> 自己質問を表示
> ユーザー喜ぶ


<!-- end of auto-generated comment: release notes by openai -->