### PR TITLE
chore: fabにアニメーションを指定

### DIFF
--- a/src/components/common/AddFab.tsx
+++ b/src/components/common/AddFab.tsx
@@ -1,21 +1,47 @@
-import { Box, Fab } from '@mui/material';
+import { Box, Fab, Zoom, keyframes } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { AddModal } from './AddModal';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(90deg);
+  }
+`;
 
 export const AddFab = () => {
   const [open, setOpen] = useState(false);
+  const [rotateIcon, setRotateIcon] = useState(true);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setRotateIcon(false);
+    }, 500); // 0.5秒後にアニメーションを停止
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+
   return (
     <>
       <Box
         role="presentation"
         sx={{ position: 'fixed', bottom: 80, right: 16 }}
       >
-        <Fab color="info" onClick={handleOpen}>
-          <AddIcon />
-        </Fab>
+        <Zoom in={true} timeout={300}>
+          <Fab color="info" onClick={handleOpen}>
+            <AddIcon
+              sx={rotateIcon ? { animation: `${rotate} 0.5s linear` } : {}}
+            />
+          </Fab>
+        </Zoom>
       </Box>
       <AddModal open={open} handleClose={handleClose} />
     </>


### PR DESCRIPTION
- close #28 
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

リリースノート:

- 機能追加: MUIのZoomとkeyframesを使用してFabコンポーネントにアニメーションを追加しました。rotateIconステート変数とuseEffectフックも導入され、アニメーションを制御します。

> "輝くFab、回転するアイコン。
> ユーザーを魅了する新機能誕生！
> ズームとキーフレームでアニメーションを追加しました。
> これでUIはより鮮やかに、楽しくなります！"
<!-- end of auto-generated comment: release notes by openai -->